### PR TITLE
AWS Integrations Docs

### DIFF
--- a/builtin/aws/alb/README.md
+++ b/builtin/aws/alb/README.md
@@ -1,3 +1,21 @@
-## Getting Started
+## AWS ALB
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS ALB plugin releases applications deployed to AWS by attaching [target
+groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html)
+to an [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html).
+
+### Components
+
+1. [ReleaseManager](./components/release-manager/README.md)
+
+### Related Plugins
+
+1. [AWS EC2](../ec2/README.md)
+2. [AWS Lambda](../lambda/README.md)
+
+### Resources
+
+1. Security group
+2. Load Balancer
+3. Listener
+4. Record Set

--- a/builtin/aws/alb/README.md
+++ b/builtin/aws/alb/README.md
@@ -6,12 +6,12 @@ to an [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/
 
 ### Components
 
-1. [ReleaseManager](./components/release-manager/README.md)
+1. [ReleaseManager](/waypoint/integrations/aws-alb/latest/components/release-manager)
 
 ### Related Plugins
 
-1. [AWS EC2](../ec2/README.md)
-2. [AWS Lambda](../lambda/README.md)
+1. [AWS EC2](/waypoint/integrations/aws-ec2)
+2. [AWS Lambda](/waypoint/integrations/aws-lambda)
 
 ### Resources
 

--- a/builtin/aws/alb/metadata.hcl
+++ b/builtin/aws/alb/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS Application Load Balancer"
-  description = "TODO"
+  description = "The AWS ALB plugin releases applications deployed to AWS by attaching target groups to an ALB."
   identifier  = "waypoint/aws-alb"
   components  = ["release-manager"]
   flags       = ["builtin"]

--- a/builtin/aws/ami/README.md
+++ b/builtin/aws/ami/README.md
@@ -5,8 +5,8 @@ to be deployed as an [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/c
 
 ### Components
 
-1. [Builder](./components/builder/README.md)
+1. [Builder](/waypoint/integrations/aws-ami/latest/components/builder)
 
 ### Related Plugins
 
-1. [AWS EC2](../ec2/README.md)
+1. [AWS EC2](/waypoint/integrations/aws-ec2)

--- a/builtin/aws/ami/README.md
+++ b/builtin/aws/ami/README.md
@@ -1,3 +1,12 @@
-## Getting Started
+## AWS AMI
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS AMI plugin searches for an returns an existing [AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html),
+to be deployed as an [EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html).
+
+### Components
+
+1. [Builder](./components/builder/README.md)
+
+### Related Plugins
+
+1. [AWS EC2](../ec2/README.md)

--- a/builtin/aws/ami/metadata.hcl
+++ b/builtin/aws/ami/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS AMI"
-  description = "TODO"
+  description = "The AWS AMI plugin searches for an returns an existing AMI, to be deployed as an EC2."
   identifier  = "waypoint/aws-ami"
   components  = ["builder"]
   flags       = ["builtin"]

--- a/builtin/aws/ec2/README.md
+++ b/builtin/aws/ec2/README.md
@@ -8,8 +8,8 @@ The AWS EC2 plugin deploys an AWS AMI as a virtual machine, running on AWS EC2.
 
 ### Related Plugins
 
-1. [AWS AMI](../ami/README.md)
-2. [AWS ALB](../alb/README.md)
+1. [AWS AMI](/waypoint/integrations/aws-ami)
+2. [AWS ALB](/waypoint/integrations/aws-alb)
 
 <!--This plugin does not implement the resource manager framework, so the 
 "Resources" section is omitted-->

--- a/builtin/aws/ec2/README.md
+++ b/builtin/aws/ec2/README.md
@@ -1,3 +1,15 @@
-## Getting Started
+## AWS EC2
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS EC2 plugin deploys an AWS AMI as a virtual machine, running on AWS EC2.
+
+### Components
+
+1. [Platform](./components/platform/README.md)
+
+### Related Plugins
+
+1. [AWS AMI](../ami/README.md)
+2. [AWS ALB](../alb/README.md)
+
+<!--This plugin does not implement the resource manager framework, so the 
+"Resources" section is omitted-->

--- a/builtin/aws/ec2/metadata.hcl
+++ b/builtin/aws/ec2/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS EC2"
-  description = "TODO"
+  description = "The AWS EC2 plugin deploys an AWS AMI as a virtual machine, running on AWS EC2."
   identifier  = "waypoint/aws-ec2"
   components  = ["platform"]
   flags       = ["builtin"]

--- a/builtin/aws/ecr/README.md
+++ b/builtin/aws/ecr/README.md
@@ -1,3 +1,13 @@
-## Getting Started
+## AWS ECR
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS ECR plugin pushes a Docker image to an [Elastic Container Registry](https://aws.amazon.com/ecr/getting-started/)
+on AWS.
+
+### Components
+
+1. [Registry](./components/registry/README.md)
+
+### Related Plugins
+
+1. [AWS ECR Pull](./pull/README.md)
+2. [AWS ECS](../ecs/README.md)

--- a/builtin/aws/ecr/README.md
+++ b/builtin/aws/ecr/README.md
@@ -5,9 +5,9 @@ on AWS.
 
 ### Components
 
-1. [Registry](./components/registry/README.md)
+1. [Registry](/waypoint/integrations/aws-ecr/latest/components/registry)
 
 ### Related Plugins
 
-1. [AWS ECR Pull](./pull/README.md)
-2. [AWS ECS](../ecs/README.md)
+1. [AWS ECR Pull](/waypoint/integrations/aws-ecr-pull)
+2. [AWS ECS](/waypoint/integrations/aws-ecs)

--- a/builtin/aws/ecr/metadata.hcl
+++ b/builtin/aws/ecr/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS ECR"
-  description = "TODO"
+  description = "The AWS ECR plugin pushes a Docker image to an Elastic Container Registry on AWS."
   identifier  = "waypoint/aws-ecr"
   components  = ["registry"]
   flags       = ["builtin"]

--- a/builtin/aws/ecr/pull/README.md
+++ b/builtin/aws/ecr/pull/README.md
@@ -7,10 +7,10 @@ deployed to [AWS ECS](https://aws.amazon.com/ecs/getting-started/).
 
 ### Components
 
-1. [Builder](./components/builder/README.md)
+1. [Builder](/waypoint/integrations/aws-ecr-pull/latest/components/builder)
 
 ### Related Plugins
 
-1. [AWS ECR](../README.md)
-2. [AWS Lambda](../../lambda/README.md)
-2. [Docker](../../../docker/README.md)
+1. [AWS ECR](/waypoint/integrations/aws-ecr)
+1. [AWS Lambda](/waypoint/integrations/aws-lambda)
+1. [Docker](/waypoint/integrations/docker)

--- a/builtin/aws/ecr/pull/README.md
+++ b/builtin/aws/ecr/pull/README.md
@@ -1,3 +1,16 @@
-## Getting Started
+## AWS ECR Pull
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS ECR Pull plugin references an existing image, if found, in an AWS
+[Elastic Container Registry](https://aws.amazon.com/ecr/getting-started/).
+The image information can be used to push an image to a new registry, or be 
+deployed to [AWS ECS](https://aws.amazon.com/ecs/getting-started/).
+
+### Components
+
+1. [Builder](./components/builder/README.md)
+
+### Related Plugins
+
+1. [AWS ECR](../README.md)
+2. [AWS Lambda](../../lambda/README.md)
+2. [Docker](../../../docker/README.md)

--- a/builtin/aws/ecr/pull/metadata.hcl
+++ b/builtin/aws/ecr/pull/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS ECR Pull"
-  description = "TODO"
+  description = "The AWS ECR Pull plugin references an existing image, if found, in an AWS Elastic Container Registry. The image information can be used to push an image to a new registry, or be deployed to AWS ECS."
   identifier  = "waypoint/aws-ecr-pull"
   components  = ["builder"]
   flags       = ["builtin"]

--- a/builtin/aws/ecs/README.md
+++ b/builtin/aws/ecs/README.md
@@ -1,3 +1,31 @@
-## Getting Started
+## AWS ECS
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS ECS plugin deploys an application image to an AWS [ECS cluster](https://aws.amazon.com/ecs/getting-started/).
+It also launches on-demand runners to do operations remotely.
+
+### Components
+
+1. [Platform](./components/platform/README.md)
+2. [TaskLauncher](./components/task/README.md)
+
+### Related Plugins
+
+1. [Docker](../../docker/README.md)
+2. [AWS ECR](../ecr/README.md)
+
+### Resources
+
+1. ECS Cluster
+2. IAM Execution Role 
+3. IAM Task Role
+4. Internal Security Group
+5. External Security Group
+6. Log Group
+7. Service Subnets
+8. ALB subnets
+9. Target Group
+10. ALB
+11. ALB listener
+12. Route53 Record
+13. Task Definition
+14. Service

--- a/builtin/aws/ecs/README.md
+++ b/builtin/aws/ecs/README.md
@@ -5,13 +5,13 @@ It also launches on-demand runners to do operations remotely.
 
 ### Components
 
-1. [Platform](./components/platform/README.md)
-2. [TaskLauncher](./components/task/README.md)
+1. [Platform](/waypoint/integrations/aws-ecs/latest/components/platform)
+2. [TaskLauncher](/waypoint/integrations/aws-ecs/latest/components/task)
 
 ### Related Plugins
 
-1. [Docker](../../docker/README.md)
-2. [AWS ECR](../ecr/README.md)
+1. [Docker](/waypoint/integrations/docker)
+2. [AWS ECR](/waypoint/integrations/aws-ecr)
 
 ### Resources
 

--- a/builtin/aws/ecs/metadata.hcl
+++ b/builtin/aws/ecs/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS ECS"
-  description = "TODO"
+  description = "The AWS ECS plugin deploys an application image to an AWS ECS cluster. It also launches on-demand runners to do operations remotely."
   identifier  = "waypoint/aws-ecs"
   components  = ["platform", "task"]
   flags       = ["builtin"]

--- a/builtin/aws/lambda/README.md
+++ b/builtin/aws/lambda/README.md
@@ -1,3 +1,16 @@
-## Getting Started
+## AWS Lambda
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS Lambda plugin deploys OCI images as functions to [AWS Lambda](https://aws.amazon.com/lambda/getting-started/).
+
+### Components
+
+1. [Platform](./components/platform/README.md)
+
+### Related Plugins
+
+1. [Docker](../../docker/README.md)
+2. [AWS ECR](../ecr/README.md)
+3. [AWS Lambda Function URL](./function_url/README.md)
+
+<!--This plugin does not implement the resource manager framework, so the 
+"Resources" section is omitted-->

--- a/builtin/aws/lambda/README.md
+++ b/builtin/aws/lambda/README.md
@@ -4,13 +4,13 @@ The AWS Lambda plugin deploys OCI images as functions to [AWS Lambda](https://aw
 
 ### Components
 
-1. [Platform](./components/platform/README.md)
+1. [Platform](/waypoint/integrations/aws-lambda/latest/components/platform)
 
 ### Related Plugins
 
-1. [Docker](../../docker/README.md)
-2. [AWS ECR](../ecr/README.md)
-3. [AWS Lambda Function URL](./function_url/README.md)
+1. [Docker](/waypoint/integrations/docker)
+2. [AWS ECR](/waypoint/integrations/aws-ecr)
+3. [AWS Lambda Function URL](/waypoint/integrations/lambda-function-url)
 
 <!--This plugin does not implement the resource manager framework, so the 
 "Resources" section is omitted-->

--- a/builtin/aws/lambda/function_url/README.md
+++ b/builtin/aws/lambda/function_url/README.md
@@ -4,11 +4,11 @@ The AWS Lambda Function URL plugin releases a function deployed with the AWS
 Lambda plugin by creating a [Lambda function URL](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html).
 
 ### Components
-1.[ReleaseManager](./components/release-manager/README.md)
+1.[ReleaseManager](/waypoint/integrations/lambda-function-url/latest/components/release-manager)
 
 ### Related Plugins
 
-1. [AWS Lambda](../README.md)
+1. [AWS Lambda](/waypoint/integrations/aws-lambda)
 
 ### Resources
 

--- a/builtin/aws/lambda/function_url/README.md
+++ b/builtin/aws/lambda/function_url/README.md
@@ -1,3 +1,16 @@
-## Getting Started
+## AWS Lambda Function URL
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS Lambda Function URL plugin releases a function deployed with the AWS 
+Lambda plugin by creating a [Lambda function URL](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html).
+
+### Components
+1.[ReleaseManager](./components/release-manager/README.md)
+
+### Related Plugins
+
+1. [AWS Lambda](../README.md)
+
+### Resources
+
+1. Function Permission
+2. Function URL

--- a/builtin/aws/lambda/metadata.hcl
+++ b/builtin/aws/lambda/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS Lambda"
-  description = "TODO"
+  description = "The AWS Lambda plugin deploys OCI images as functions to AWS Lambda."
   identifier  = "waypoint/aws-lambda"
   components  = ["platform"]
   flags       = ["builtin"]

--- a/builtin/aws/ssm/README.md
+++ b/builtin/aws/ssm/README.md
@@ -1,3 +1,7 @@
-## Getting Started
+## AWS SSM
 
-TODO, Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+The AWS SSM plugin reads configuration values from the [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html).
+
+### Components
+
+1. ConfigSourcer

--- a/builtin/aws/ssm/metadata.hcl
+++ b/builtin/aws/ssm/metadata.hcl
@@ -1,6 +1,6 @@
 integration {
   name        = "AWS SSM"
-  description = "TODO"
+  description = "The AWS SSM plugin reads configuration values from the AWS SSM Parameter Store."
   identifier  = "waypoint/aws-ssm"
   components  = ["config-sourcer"]
   flags       = ["builtin"]


### PR DESCRIPTION
This PR contains documentation for the AWS Waypoint plugins to fulfill the format required for the new DevDot integrations project. The general structure of the top-level README per-plugin is as follows:

```
## Name of Plugin

Brief plugin description.

### Components

1. The list of components which are implemented by the plugin, with a link to the README of the component.

### Related plugins

1. A list of plugins for which this plugin may produce output, or from which may consume input.
2. For example, the AWS Lambda plugin consumes a Docker image as input, and produces an AWS Lambda function deployment as output for the AWS Lambda function URL to consume, so it is (at least) _related_ to both of those.
3. Regarding config sourcers, they can be used with an app instance deployed to _any_ platform, so I did not have a section for the config sourcer plugin added in this PR (AWS SSM). We can decide on that later if desired.

### Resources

1. If the plugin implements the Platform or ReleaseManager components, _and_ uses the resource manager framework from the Waypoint plugin SDK, the resources managed by the framework are listed in this section.
```

The metadata.hcl `description` field for now is just a copy and paste of the brief description of the plugin from the README. Happy to change this later as well.