### PR TITLE
chore: fix docs; handle empty sections

### DIFF
--- a/builtin/aws/ami/components/builder/README.md
+++ b/builtin/aws/ami/components/builder/README.md
@@ -3,5 +3,6 @@ Search for and return an existing AMI.
 
 ### Interface
 
+- Input: **component.Source**
 - Output: **ami.Image**
 

--- a/builtin/aws/ec2/components/platform/parameters.hcl
+++ b/builtin/aws/ec2/components/platform/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "count"
   description = "how many EC2 instances to configure the ASG with\nthe fields here (desired, min, max) map directly to the typical ASG configuration"
   type        = "ec2.countConfig"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/aws/ecs/components/platform/parameters.hcl
+++ b/builtin/aws/ecs/components/platform/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "alb"
   description = "Provides additional configuration for using an ALB with ECS"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -133,7 +133,7 @@ parameter {
   key         = "logging"
   description = "Provides additional configuration for logging flags for ECS\nPart of the ecs task definition.  These configuration flags help control how the awslogs log driver is configured."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/aws/ecs/components/task/README.md
+++ b/builtin/aws/ecs/components/task/README.md
@@ -6,5 +6,3 @@ source authentication information for AWS, using the configured task role.
 If no task role name is specified, Waypoint will create one with the required
 permissions.
 
-### Interface
-

--- a/builtin/aws/lambda/components/platform/outputs.hcl
+++ b/builtin/aws/lambda/components/platform/outputs.hcl
@@ -18,6 +18,12 @@ output {
 }
 
 output {
+  key         = "storage"
+  description = ""
+  type        = "int64"
+}
+
+output {
   key         = "target_group_arn"
   description = ""
   type        = "string"

--- a/builtin/aws/lambda/function_url/components/release-manager/README.md
+++ b/builtin/aws/lambda/function_url/components/release-manager/README.md
@@ -12,6 +12,9 @@ Create an AWS Lambda function URL.
 release {
 	use "lambda-function-url" {
 		auth_type = "NONE"
+		cors {
+			allow_methods = ["*"]
+		}
 	}
 }
 ```

--- a/builtin/aws/lambda/function_url/components/release-manager/parameters.hcl
+++ b/builtin/aws/lambda/function_url/components/release-manager/parameters.hcl
@@ -8,6 +8,62 @@ parameter {
 }
 
 parameter {
+  key           = "cors"
+  description   = "CORS configuration for the function URL"
+  type          = "category"
+  required      = false
+  default_value = "NONE"
+}
+
+parameter {
+  key           = "cors.allow_credentials"
+  description   = "Whether to allow cookies or other credentials in requests to your function URL."
+  type          = "bool"
+  required      = false
+  default_value = "false"
+}
+
+parameter {
+  key           = "cors.allow_headers"
+  description   = "The HTTP headers that origins can include in requests to your function URL. For example: Date, Keep-Alive, X-Custom-Header."
+  type          = "list of string"
+  required      = false
+  default_value = "[]"
+}
+
+parameter {
+  key           = "cors.allow_methods"
+  description   = "The HTTP methods that are allowed when calling your function URL. For example: GET, POST, DELETE, or the wildcard character (*)."
+  type          = "list of string"
+  required      = false
+  default_value = "[]"
+}
+
+parameter {
+  key           = "cors.allow_origins"
+  description   = "The origins that can access your function URL. You can list any number of specific origins, separated by a comma. You can grant access to all origins using the wildcard character (*)."
+  type          = "list of string"
+  required      = false
+  default_value = "[]"
+}
+
+parameter {
+  key           = "cors.expose_headers"
+  description   = "The HTTP headers in your function response that you want to expose to origins that call your function URL. For example: Date, Keep-Alive, X-Custom-Header."
+  type          = "list of string"
+  required      = false
+  default_value = "[]"
+}
+
+parameter {
+  key           = "cors.max_age"
+  description   = "The maximum amount of time, in seconds, that web browsers can cache results of a preflight request."
+  type          = "int64"
+  required      = false
+  default_value = "0"
+}
+
+parameter {
   key           = "principal"
   description   = "the principal to use when auth_type is `AWS_IAM`\nThe Principal parameter specifies the principal that is allowed to invoke the function."
   type          = "string"

--- a/builtin/aws/ssm/components/config-sourcer/README.md
+++ b/builtin/aws/ssm/components/config-sourcer/README.md
@@ -1,8 +1,6 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
 Read configuration values from AWS SSM Parameter Store.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/consul/components/config-sourcer/README.md
+++ b/builtin/consul/components/config-sourcer/README.md
@@ -1,6 +1,3 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
 Read configuration values from the Consul KV store.
 
-### Interface
-
-<!-- The empty interface section needs to be updated -->

--- a/builtin/docker/components/builder/README.md
+++ b/builtin/docker/components/builder/README.md
@@ -20,6 +20,7 @@ to specify any additional configuration.
 
 ### Interface
 
+- Input: **component.Source**
 - Output: **docker.Image**
 
 ### Examples

--- a/builtin/docker/components/builder/parameters.hcl
+++ b/builtin/docker/components/builder/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "auth"
   description = "the authentication information to log into the docker repository"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/docker/components/platform/parameters.hcl
+++ b/builtin/docker/components/platform/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "auth"
   description = "the authentication information to log into the docker repository"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -73,7 +73,7 @@ parameter {
   key         = "client_config"
   description = "client config for remote Docker engine\nthis config block can be used to configure a remote Docker engine. By default Waypoint will attempt to discover this configuration using the environment variables: `DOCKER_HOST` to set the url to the docker server. `DOCKER_API_VERSION` to set the version of the API to reach, leave empty for latest. `DOCKER_CERT_PATH` to load the TLS certificates from. `DOCKER_TLS_VERIFY` to enable or disable TLS verification, off by default."
   type        = "docker.ClientConfig"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/docker/components/registry/parameters.hcl
+++ b/builtin/docker/components/registry/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "auth"
   description = "the authentication information to log into the docker repository"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/docker/components/task/README.md
+++ b/builtin/docker/components/task/README.md
@@ -4,8 +4,6 @@ Launch a Docker container as a task.
 If a Docker server is available (either locally or via environment variables
 such as "DOCKER_HOST"), then it will be used to start the container.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/docker/components/task/parameters.hcl
+++ b/builtin/docker/components/task/parameters.hcl
@@ -10,7 +10,7 @@ parameter {
   key         = "client_config"
   description = ""
   type        = "docker.ClientConfig"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -46,7 +46,7 @@ parameter {
   key         = "resources"
   description = "The resources that the tasks should use."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/docker/pull/components/builder/parameters.hcl
+++ b/builtin/docker/pull/components/builder/parameters.hcl
@@ -3,7 +3,7 @@ parameter {
   key         = "auth"
   description = "the authentication information to log into the docker repository"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/files/components/builder/README.md
+++ b/builtin/files/components/builder/README.md
@@ -3,6 +3,9 @@ Generates a value representing a path on disk.
 
 ### Interface
 
+- Input: **component.Source**
+- Output: **files.Files**
+
 ### Examples
 
 ```hcl

--- a/builtin/files/components/registry/README.md
+++ b/builtin/files/components/registry/README.md
@@ -3,6 +3,9 @@ Copies files to a specific directory.
 
 ### Interface
 
+- Input: **files.Files**
+- Output: **files.Files**
+
 ### Examples
 
 ```hcl

--- a/builtin/google/cloudrun/components/platform/README.md
+++ b/builtin/google/cloudrun/components/platform/README.md
@@ -3,6 +3,9 @@ Deploy a container to Google Cloud Run.
 
 ### Interface
 
+- Input: **docker.Image**
+- Output: **google.cloudrun.Deployment**
+
 ### Examples
 
 ```hcl

--- a/builtin/google/cloudrun/components/platform/parameters.hcl
+++ b/builtin/google/cloudrun/components/platform/parameters.hcl
@@ -106,7 +106,7 @@ parameter {
   key         = "vpc_access"
   description = "VPCAccess details"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/google/cloudrun/components/release-manager/README.md
+++ b/builtin/google/cloudrun/components/release-manager/README.md
@@ -3,3 +3,6 @@ Manipulates the Cloud Run APIs to make deployments active.
 
 ### Interface
 
+- Input: **google.cloudrun.Deployment**
+- Output: **google.cloudrun.Release**
+

--- a/builtin/k8s/apply/components/platform/README.md
+++ b/builtin/k8s/apply/components/platform/README.md
@@ -57,6 +57,9 @@ below for more details.
 
 ### Interface
 
+- Input: **None**
+- Output: **k8sapply.Deployment**
+
 ### Examples
 
 ```hcl

--- a/builtin/k8s/canary/components/release-manager/parameters.hcl
+++ b/builtin/k8s/canary/components/release-manager/parameters.hcl
@@ -1,0 +1,15 @@
+# This file was generated via `make gen/integrations-hcl`
+parameter {
+  key         = "fail_deployment"
+  description = "If true, marks the deployment as failed."
+  type        = "bool"
+  required    = false
+}
+
+parameter {
+  key         = "groups"
+  description = "List of task group names which are to be promoted."
+  type        = "list of string"
+  required    = false
+}
+

--- a/builtin/k8s/canary/components/release-manager/readme.md
+++ b/builtin/k8s/canary/components/release-manager/readme.md
@@ -1,0 +1,123 @@
+<!-- This file was generated via `make gen/integrations-hcl` -->
+Promotes a Nomad canary deployment initiated by a Nomad jobspec deployment.
+
+If your Nomad deployment is configured to use canaries, this releaser plugin lets
+you promote (or fail) the canary deployment. You may also target specific task
+groups within your job for promotion, if you have multiple task groups in your canary
+deployment.
+
+-> **Note:** Using the `-prune=false` flag is recommended for this releaser. By default,
+Waypoint prunes and destroys all unreleased deployments and keeps only one previous
+deployment. Therefore, if `-prune=false` is not set, Waypoint may delete
+your job via "pruning" a previous version. See [deployment pruning](/waypoint/docs/lifecycle/release#deployment-pruning)
+for more information.
+
+### Release URL
+
+If you want the URL of the release of your deployment to be published in Waypoint,
+you must set the meta 'waypoint.hashicorp.com/release_url' in your jobspec. The
+value specified in this meta field will be published as the release URL for your
+application. In the future, this may source from Consul.
+
+### Interface
+
+- Input: **jobspec.Deployment**
+
+### Examples
+
+```hcl
+// The waypoint.hcl file
+release {
+  use "nomad-jobspec-canary" {
+    groups = [
+      "app"
+    ]
+  }
+}
+
+// The app.nomad.tpl file
+job "web" {
+  datacenters = ["dc1"]
+
+  group "app" {
+    network {
+      mode = "bridge"
+      port "http" {
+        to = 80
+      }
+    }
+
+    // Setting a canary in the update stanza indicates a canary deployment
+    update {
+      max_parallel = 1
+      canary       = 1
+      auto_revert  = true
+      auto_promote = false
+      health_check = "task_states"
+    }
+
+    service {
+      name = "app"
+      port = 80
+      connect {
+        sidecar_service {}
+      }
+    }
+
+    task "app" {
+      driver = "docker"
+      config {
+        image = "${artifact.image}:${artifact.tag}"
+        ports  = ["http"]
+      }
+
+      env {
+        %{ for k,v in entrypoint.env ~}
+        ${k} = "${v}"
+        %{ endfor ~}
+
+        // Ensure we set PORT for the URL service. This is only necessary
+        // if we want the URL service to function.
+        PORT = 80
+      }
+    }
+  }
+
+  group "app-gateway" {
+    network {
+      mode = "bridge"
+      port "inbound" {
+        static = 8080
+        to     = 8080
+      }
+    }
+
+    service {
+      name = "gateway"
+      port = "8080"
+
+      connect {
+        gateway {
+          proxy {}
+
+          ingress {
+            listener {
+              port = 8080
+              protocol = "http"
+              service {
+                name  = "app"
+                hosts = [ "*" ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  meta = {
+    // Ensure we set meta for Waypoint to detect the release URL
+    "waypoint.hashicorp.com/release_url" = "http://app.ingress.dc1.consul:8080"
+  }
+}
+```
+

--- a/builtin/k8s/components/config-sourcer/README.md
+++ b/builtin/k8s/components/config-sourcer/README.md
@@ -1,8 +1,6 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
 Read configuration values from Kubernetes ConfigMap or Secret resources. Note that to read a config value from a Secret, you must set `secret = true`. Otherwise Waypoint will load a dynamic value from a ConfigMap.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/k8s/components/platform/README.md
+++ b/builtin/k8s/components/platform/README.md
@@ -3,6 +3,9 @@ Deploy the application into a Kubernetes cluster using Deployment objects.
 
 ### Interface
 
+- Input: **docker.Image**
+- Output: **k8s.Deployment**
+
 ### Examples
 
 ```hcl

--- a/builtin/k8s/components/platform/parameters.hcl
+++ b/builtin/k8s/components/platform/parameters.hcl
@@ -10,7 +10,7 @@ parameter {
   key         = "autoscale"
   description = "sets up a horizontal pod autoscaler to scale deployments automatically\nThis configuration will automatically set up and associate the current deployment with a horizontal pod autoscaler in Kuberentes. Note that for this to work, you must also define resource limits and requests for a deployment otherwise the metrics-server will not be able to properly determine a deployments target CPU utilization"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -45,7 +45,7 @@ parameter {
   key         = "cpu"
   description = "cpu resource configuration\nCPU lets you define resource limits and requests for a container in a deployment."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -87,7 +87,7 @@ parameter {
   key         = "memory"
   description = "memory resource configuration\nMemory lets you define resource limits and requests for a container in a deployment."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -143,7 +143,7 @@ parameter {
   key         = "pod.container.cpu"
   description = "cpu resource configuration\nCPU lets you define resource limits and requests for a container in a deployment."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -164,7 +164,7 @@ parameter {
   key         = "pod.container.memory"
   description = "memory resource configuration\nMemory lets you define resource limits and requests for a container in a deployment."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -235,7 +235,7 @@ parameter {
   key         = "pod.container.probe"
   description = "configuration to control liveness and readiness probes\nProbe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -350,7 +350,7 @@ parameter {
   key         = "pod.sidecar.container.cpu"
   description = "cpu resource configuration\nCPU lets you define resource limits and requests for a container in a deployment."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -371,7 +371,7 @@ parameter {
   key         = "pod.sidecar.container.memory"
   description = "memory resource configuration\nMemory lets you define resource limits and requests for a container in a deployment."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -442,7 +442,7 @@ parameter {
   key         = "pod.sidecar.container.probe"
   description = "configuration to control liveness and readiness probes\nProbe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -501,7 +501,7 @@ parameter {
   key         = "probe"
   description = "configuration to control liveness and readiness probes\nProbe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/k8s/components/release-manager/README.md
+++ b/builtin/k8s/components/release-manager/README.md
@@ -3,3 +3,6 @@ Manipulates the Kubernetes Service activate Deployments.
 
 ### Interface
 
+- Input: **k8s.Deployment**
+- Output: **k8s.Release**
+

--- a/builtin/k8s/components/release-manager/parameters.hcl
+++ b/builtin/k8s/components/release-manager/parameters.hcl
@@ -17,7 +17,7 @@ parameter {
   key         = "ingress"
   description = "Configuration to set up an ingress resource to route traffic to the given application from an ingress controller\nAn ingress resource can be created on release that will route traffic to the Kubernetes service. Note that before this happens, the Kubernetes cluster must already be configured with an Ingress controller. Otherwise there won't be a way for inbound traffic to be routed to the ingress resource."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -62,7 +62,7 @@ parameter {
   key         = "ingress.tls"
   description = "A stanza of TLS configuration options for traffic to the ingress resource"
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/k8s/components/task/README.md
+++ b/builtin/k8s/components/task/README.md
@@ -7,8 +7,6 @@ itself (typical for a Kubernetes-based installation), it will use the pod's
 service account unless other auth is explicitly given. This allows the task
 launcher to work by default.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/k8s/components/task/parameters.hcl
+++ b/builtin/k8s/components/task/parameters.hcl
@@ -10,14 +10,14 @@ parameter {
   key         = "cpu"
   description = "cpu resource request to be added to the task container"
   type        = "k8s.ResourceConfig"
-  required    = true
+  required    = false
 }
 
 parameter {
   key         = "ephemeral_storage"
   description = "ephemeral_storage resource request to be added to the task container"
   type        = "k8s.ResourceConfig"
-  required    = true
+  required    = false
 }
 
 parameter {
@@ -45,7 +45,7 @@ parameter {
   key         = "memory"
   description = "memory resource request to be added to the task container"
   type        = "k8s.ResourceConfig"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/k8s/helm/components/platform/README.md
+++ b/builtin/k8s/helm/components/platform/README.md
@@ -35,6 +35,9 @@ below for more details.
 
 ### Interface
 
+- Input: **None**
+- Output: **k8s_helm.Deployment**
+
 ### Examples
 
 ```hcl

--- a/builtin/nomad/components/platform/README.md
+++ b/builtin/nomad/components/platform/README.md
@@ -1,7 +1,10 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
-Deploy to a Nomad cluster as a service using Docker.
+Deploy to a nomad cluster as a service using Docker.
 
 ### Interface
+
+- Input: **docker.Image**
+- Output: **nomad.Deployment**
 
 ### Examples
 

--- a/builtin/nomad/components/platform/parameters.hcl
+++ b/builtin/nomad/components/platform/parameters.hcl
@@ -48,7 +48,7 @@ parameter {
   key         = "resources"
   description = "The amount of resources to allocate to the deployed allocation."
   type        = "category"
-  required    = true
+  required    = false
 }
 
 parameter {

--- a/builtin/nomad/components/task/README.md
+++ b/builtin/nomad/components/task/README.md
@@ -4,8 +4,6 @@ Launch a Nomad job for on-demand tasks from the Waypoint server.
 This will use the standard Nomad environment used for with the server install
 to launch on demand Nomad jobs for Waypoint server tasks.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/nomad/jobspec/components/platform/README.md
+++ b/builtin/nomad/jobspec/components/platform/README.md
@@ -52,6 +52,9 @@ below for more details.
 
 ### Interface
 
+- Input: **docker.Image**
+- Output: **jobspec.Deployment**
+
 ### Examples
 
 ```hcl

--- a/builtin/nomad/platform.go
+++ b/builtin/nomad/platform.go
@@ -466,7 +466,7 @@ func (p *Platform) Documentation() (*docs.Documentation, error) {
 		return nil, err
 	}
 
-	doc.Description("Deploy to a nomad cluster as a service using docker")
+	doc.Description("Deploy to a nomad cluster as a service using Docker")
 	doc.Input("docker.Image")
 	doc.Output("nomad.Deployment")
 

--- a/builtin/packer/components/config-sourcer/readme.md
+++ b/builtin/packer/components/config-sourcer/readme.md
@@ -1,8 +1,6 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
 Retrieve the image ID of an image whose metadata is pushed to an HCP Packer registry. The image ID is that of the HCP Packer bucket iteration assigned to the configured channel, with a matching cloud provider and region.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/packer/config_sourcer.go
+++ b/builtin/packer/config_sourcer.go
@@ -158,8 +158,8 @@ func (cs *ConfigSourcer) Documentation() (*docs.Documentation, error) {
 	}
 
 	doc.Description("Retrieve the image ID of an image whose metadata is pushed " +
-		"to an HCP Packer registry. The image ID is that of the HCP Packer bucket" +
-		"iteration assigned to the configured channel, with a matching cloud provider" +
+		"to an HCP Packer registry. The image ID is that of the HCP Packer bucket " +
+		"iteration assigned to the configured channel, with a matching cloud provider " +
 		"and region.")
 
 	doc.Example(`

--- a/builtin/tfc/components/config-sourcer/README.md
+++ b/builtin/tfc/components/config-sourcer/README.md
@@ -1,8 +1,6 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
 Read Terraform state outputs from Terraform Cloud.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/builtin/vault/components/config-sourcer/README.md
+++ b/builtin/vault/components/config-sourcer/README.md
@@ -1,8 +1,6 @@
 <!-- This file was generated via `make gen/integrations-hcl` -->
 Read configuration values from Vault.
 
-### Interface
-
 ### Examples
 
 ```hcl

--- a/internal/cli/app_docs.go
+++ b/internal/cli/app_docs.go
@@ -439,7 +439,6 @@ func removeEmptyStrings(s []string) []string {
 }
 
 // generates README.md, parameters.hcl, and outputs.hcl for builtin plugins' components
-// TODO: consider treating config-sourcers differently
 func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 	// example target = builtin/aws/ami/components/builder/outputs.hcl
 
@@ -502,7 +501,7 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 		os.MkdirAll(fmt.Sprintf("./builtin/%s/components/%s", pluginPath, componentSlug), os.ModePerm)
 
 		// populate README.md
-		readme, err := os.Create(fmt.Sprintf("./builtin/%s/components/%s/readme.md", pluginPath, componentSlug))
+		readme, err := os.Create(fmt.Sprintf("./builtin/%s/components/%s/README.md", pluginPath, componentSlug))
 		if err != nil {
 			panic(err)
 		}
@@ -515,9 +514,15 @@ func (c *AppDocsCommand) hclFormat(name, ct string, doc *docs.Documentation) {
 			fmt.Fprintf(readme, "%s\n\n", c.humanize(dets.Description))
 		}
 
-		fmt.Fprintf(readme, "### Interface\n\n")
+		if componentSlug == "config-sourcer" || componentSlug == "task" {
+			// config-sourcer and task components don't have inputs or outputs
+			// don't generate interface section
+		} else {
+			fmt.Fprintf(readme, "### Interface\n\n")
+		}
 
 		space := false
+
 		if dets.Input != "" {
 			fmt.Fprintf(readme, "- Input: **%s**\n", dets.Input)
 			space = true


### PR DESCRIPTION
This updates the `make gen/integrations-hcl` command to skip generating a `Interface` section for config-sourcers and task. (These end up being empty anyways)

- https://github.com/BrandonRomano/waypoint/pull/7/files#diff-840099a82dad98ae3aee561a087b2abc42385455b64d2247153716d089fa61f3

This regenerates docs content after pulling in the most recent upstream changes